### PR TITLE
Fixed issue #10017: Make sure rand is only evaluated once each survey…

### DIFF
--- a/application/helpers/expressions/em_core_helper.php
+++ b/application/helpers/expressions/em_core_helper.php
@@ -2070,6 +2070,34 @@ class ExpressionManager {
                                         $result = NAN;
                                     }
                                     break;
+                                case 'rand':
+
+                                    // Get unique hash for this rand usage, from question id, group id, params and tokens
+                                    // TODO: Add user id too?
+                                    $flattened_tokens = implode(flattenrec($this->RDP_tokens));
+                                    $randHash = hash('md5', $this->sid . $this->questionSeq . $this->groupSeq . $params[0] . $params[1] . $flattened_tokens);
+
+                                    // Create cache if it's not there
+                                    if (!isset($_SESSION['randResultCache']))
+                                    {
+                                        $_SESSION['randResultCache'] = array();
+                                    }
+
+                                    // Return cache result if it's there; otherwise, store and return
+                                    if (isset($_SESSION['randResultCache'][$randHash]))
+                                    {
+                                        $result = $_SESSION['randResultCache'][$randHash];
+                                    }
+                                    else
+                                    {
+                                        $result = $funcName($params[0], $params[1]);
+                                        $_SESSION['randResultCache'][$randHash] = $result;
+                                    }
+
+                                    // Cache is cleared in function killSurveySession
+
+                                    break;
+
                                 default:
                                     $result = $funcName($params[0], $params[1]);
                                      break;
@@ -2925,4 +2953,11 @@ function exprmgr_unique($args)
     }
     return true;
 }
+
+function flattenrec(array $array) {
+    $return = array();
+    array_walk_recursive($array, function($a) use (&$return) { $return[] = $a; });
+    return $return;
+}
+
 ?>

--- a/application/helpers/expressions/em_manager_helper.php
+++ b/application/helpers/expressions/em_manager_helper.php
@@ -4749,7 +4749,6 @@
         /**
         * Should be first function called on each page - sets/clears internally needed variables
         * @param <type> $allOnOnePage - true if StartProcessingGroup will be called multiple times on this page - does some optimizatinos
-        * @param <type> $rooturl - if set, this tells LEM to enable hyperlinking of syntax highlighting to ease editing of questions
         * @param <boolean> $initializeVars - if true, initializes the replacement variables to enable syntax highlighting on admin pages
         */
         static function StartProcessingPage($allOnOnePage=false,$initializeVars=false)
@@ -5552,6 +5551,7 @@
                     return $LEM->lastMoveResult;
                     break;
                 case 'group':
+
                     // First validate the current group
                     $LEM->StartProcessingPage();
                     if ($processPOST)
@@ -6798,6 +6798,7 @@
             'valid' => $qvalid,
             );
             $_SESSION[$LEM->sessid]['relevanceStatus'][$qid] = $qrel;
+
             return $qStatus;
         }
 

--- a/application/helpers/frontend_helper.php
+++ b/application/helpers/frontend_helper.php
@@ -2187,6 +2187,7 @@ function killSurveySession($iSurveyID)
 {
     // Unset the session
     unset($_SESSION['survey_'.$iSurveyID]);
+    unset($_SESSION['randResultCache']);
     // Force EM to refresh
     LimeExpressionManager::SetDirtyFlag();
 }


### PR DESCRIPTION
…, using a cache for the function result

Fixed issue # : 
New feature # :
Changed feature # :
Dev: 
Dev: 